### PR TITLE
Replace cobe's Snowball stemming wrapper dependency with `stemming`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Dependencies:
 
 * [Python][python] >= 2.6
 * [lxml][lxml] >= 2.3
+* [stemming][stemming] >= 1.0
 * [psycopg][psycopg] >= 2.4 (if using RW database functions)
 
 [lxml]: http://lxml.de
 [psycopg]: http://initd.org
 [python]: http://python.org
 [rainwave]: http://rainwave.cc
+[stemming]: http://pypi.python.org/pypi/stemming

--- a/cobe/tokenizers.py
+++ b/cobe/tokenizers.py
@@ -1,9 +1,8 @@
 # Copyright (C) 2010 Peter Teichman
 
 import re
-import Stemmer
 import types
-
+from stemming import porter2
 
 class MegaHALTokenizer:
     """A traditional MegaHAL style tokenizer. This considers any of these
@@ -103,11 +102,12 @@ tokens."""
     def join(self, words):
         return u"".join(words)
 
-
+# Modified from original source by cpetosky on 3/11:
+#    Replaced Snowball dependency with stemming library.
+#    stemming is pure python and avoids Snowball's binary dependency.
 class CobeStemmer:
     def __init__(self, name):
-        # use the PyStemmer Snowball stemmer bindings
-        self.stemmer = Stemmer.Stemmer(name)
+        pass
 
     def stem(self, word):
         # Don't preserve case when stemming, i.e. create lowercase stems.
@@ -115,6 +115,6 @@ class CobeStemmer:
         # input words, but still generate the reply in context with the
         # generated case.
 
-        stem = self.stemmer.stemWord(word.lower())
+        stem = porter2.stem(word.lower())
 
         return stem


### PR DESCRIPTION
stemming is a pure python library. Snowball is written in C and uses a Python
wrapper. This is inconvenient since I occasionally develop on Windows.

William, I haven't actually tested this change; I'm working on getting unit testing working in general to make changes like this easier to stomach but I'm not there yet.

If this change is too worrisome I can build Snowball on Windows, but I generally prefer pure Python dependencies so I thought I'd try this change first.
