### PR TITLE
Allow a user to set config values via ./wormgas.py --set-*=*, also display !rps as percentages.

### DIFF
--- a/wormgas.py
+++ b/wormgas.py
@@ -147,6 +147,14 @@ class wormgas(SingleServerIRCBot):
             self.rwdb = None
 
         self.brain = Brain(self.path + "/brain.sqlite")
+
+        args = sys.argv[1:]
+        for arg in args:
+            if arg.startswith("--set-"):
+                key,value = arg[6:].split("=", 1)
+                print "Setting '%s' to '%s'." % (key, value)
+                self.config.set(key, value)
+
         self.reignore = re.compile(self.config.get("msg:ignore"))
 
         server = self.config.get("irc:server")
@@ -1435,7 +1443,10 @@ class wormgas(SingleServerIRCBot):
             r+= "You lose!"
 
         w, d, l = self.config.get_rps_record(nick)
-        r += " Your current record is %s-%s-%s (w-d-l)." % (w, d, l)
+        pw = int(float(w)/float(w+d+l)*100)
+        pd = int(float(d)/float(w+d+l)*100)
+        pl = int(float(l)/float(w+d+l)*100)
+        r += " Your current record is %s-%s-%s or %s%%-%s%%-%s%% (w-d-l)." % (w, d, l, pw, pd, pl)
 
         if channel == PRIVMSG:
             output.default.append(r)


### PR DESCRIPTION
Per the subject, this allows users to "quick start" wormgas via:

./wormgas.py --set-api:key=foo --set-api:user_id=bar --set-irc:channel=#wormgas --set-irc:name=wormie --set-irc:server=irc.synirc.net --set-privlevel:YOURNICK=2

Also, perhaps include in the README the following which lists the used config keys in wormgas.py:

grep -o 'self.config.get([^)]_)' wormgas.py | grep -o '"[^)]_' | sort | uniq
