### PR TITLE
Prevent download of big files on title fetcher.

### DIFF
--- a/util.py
+++ b/util.py
@@ -181,7 +181,7 @@ class TitleFetcher(object):
 		if url.endswith(u'.ogg'):
 			raise TitleFetcherError(u'OGG? Ain\'t nobody got time for that!')
 		try:
-			data = requests.get(url, stream=True)
+			data = requests.get(url, timeout=10, headers={'Range': 'bytes=0-1024'})
 		except:
 			m = u'There was a problem fetching data from: {}'
 			raise TitleFetcherError(m.format(url))


### PR DESCRIPTION
This should prevent wormie from trying to download big files and timing out of IRC. The precise values, may need tuning, maybe 1 KiB will prevent it from getting titles from some legit pages.

With this in place you may even want to remove the special code to handle ogg urls.
